### PR TITLE
fix: occurrence of NaN with straight lines

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -423,7 +423,7 @@ export function getAdjacentLength(angle, hip) {
  */
 export function getTangentLength(angle, opposite) {
   const a = opposite / Math.tan(angle);
-  if (a === Infinity || a === -Infinity) {
+  if (a === Infinity || a === -Infinity || isNaN(a)) {
     return opposite;
   }
 

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -20,6 +20,11 @@ describe('index', () => {
     expect(roundCommands(c, 10)).toEqual(r);
   });
 
+  it('roundCommands(): should not crash with straight lines', () => {
+    const c = cloneDeep(v.badLine);
+    expect(roundCommands(c, 50).path).not.toContain('NaN');
+  });
+
   it('roundCorners(): it should parse "d" string and add rounded corners', () => {
     expect(roundCorners(v.rawRelativeSquare, 20).path).toBe(v.computedSquare);
   });

--- a/tests/utils.spec.js
+++ b/tests/utils.spec.js
@@ -61,7 +61,11 @@ describe('utils', function() {
   it('getTangentLength(); Adjacent side should be equal opposite when angle = 0', () => {
     expect(getTangentLength(0, 100)).toBe(100); // 0° 0° 0°
   });
-  
+
+  it('getTangentLength(); Opposite equaling 0 should be 0', () => {
+    expect(getTangentLength(0, 0)).toBe(0); // 0° 0° 0°
+  });
+
   it('getTangentNoHyp(); Math.tan 45° 45° 90°', () => {
     expect(getTangentNoHyp(Math.PI / 4, 5)).toBeCloseTo(5);
   });

--- a/tests/variables.js
+++ b/tests/variables.js
@@ -212,8 +212,88 @@ const overlapped = [
       x: 216.1042,
       y: 78.4
     }
+  }
+];
+
+const badLine = [
+  {
+    marker: 'M',
+    values: {
+      x: 0,
+      y: 0
+    }
   },
-]
+  {
+    marker: 'L',
+    values: {
+      x: 61.599999999999994,
+      y: 0
+    }
+  },
+  {
+    marker: 'L',
+    values: {
+      x: 61.599999999999994,
+      y: -2.8
+    }
+  },
+  {
+    marker: 'L',
+    values: {
+      x: 267.4,
+      y: -2.8
+    }
+  },
+  {
+    marker: 'L',
+    values: {
+      x: 466.2,
+      y: -2.8
+    }
+  },
+  {
+    marker: 'L',
+    values: {
+      x: 466.2,
+      y: 25.586567164179062
+    }
+  },
+  {
+    marker: 'L',
+    values: {
+      x: 659.4,
+      y: 25.586567164179062
+    }
+  },
+  {
+    marker: 'L',
+    values: {
+      x: 690.1999999999999,
+      y: 25.586567164179062
+    }
+  },
+  {
+    marker: 'L',
+    values: {
+      x: 690.1999999999999,
+      y: 165.2
+    }
+  },
+  {
+    marker: 'L',
+    values: {
+      x: 660.0999999999999,
+      y: 165.2
+    }
+  },
+  {
+    marker: 'L',
+    values: {
+      x: 910.3499999999999,
+      y: 165.2
+    }
+  }
+];
 
 export {
   rawRelativeSquare,
@@ -224,4 +304,5 @@ export {
   relativeCommands,
   relativeCommandsHV,
   overlapped,
-}
+  badLine
+};


### PR DESCRIPTION
Hi @BrunoFenzl! Thanks for a great library, we're using this to draw elbow connectors for tryeraser.com.


We found that if both `angle` and `opposite` are zero, `getTangentLength` would return NaN, and that would make it into the SVG path string. This adds a check for NaN and returns zero instead.